### PR TITLE
Replace reading file with inlined source code

### DIFF
--- a/lib/babel-plugin-inject-decorator-initializer.js
+++ b/lib/babel-plugin-inject-decorator-initializer.js
@@ -1,16 +1,14 @@
 const {template, types: t} = require('@babel/core');
-const {readFileSync} = require('fs');
-const {resolve} = require('path');
 
-// Index of the char that ends `export default` expression
-// in the runtime-injector.js
-const EXPORT_END_INDEX = 15;
-
-const runtimeInjectFile = readFileSync(resolve(__dirname, './runtime-injector.js'), 'utf8').slice(
-  EXPORT_END_INDEX,
-);
-
-const buildFunction = template(runtimeInjectFile);
+const buildFunction = template(`
+function _injectDecoratorInitializer(target, callbacks) {
+  if (Array.isArray(callbacks)) {
+    for (var i = 0; i < callbacks.length; i++) {
+      callbacks[i](target);
+    }
+  }
+}
+`);
 const buildCall = template('_injectDecoratorInitializer(TARGET, CLASS.PROP);');
 const buildImport = template(
   'import _injectDecoratorInitializer from "@corpuscule/babel-preset/lib/runtime-injector";',


### PR DESCRIPTION
This PR replaces reading `runtime-injector` file with the source code of the `_injectDecoratorInitializer` function. It is necessary because the file system may be unavailable for the target of the `@babel/register`.