### PR TITLE
Remove unnecessary checking for array in the injector function

### DIFF
--- a/lib/babel-plugin-inject-decorator-initializer.js
+++ b/lib/babel-plugin-inject-decorator-initializer.js
@@ -6,10 +6,8 @@ const {template, types: t} = require('@babel/core');
 
 const buildFunction = template(`
 function _injectDecoratorInitializer(target, callbacks) {
-  if (Array.isArray(callbacks)) {
-    for (var i = 0; i < callbacks.length; i++) {
-      callbacks[i](target);
-    }
+  for (var i = 0; i < callbacks.length; i++) {
+    callbacks[i](target);
   }
 }
 `);

--- a/lib/runtime-injector.js
+++ b/lib/runtime-injector.js
@@ -1,7 +1,5 @@
 export default function _injectDecoratorInitializer(target, callbacks) {
-  if (Array.isArray(callbacks)) {
-    for (var i = 0; i < callbacks.length; i++) {
-      callbacks[i](target);
-    }
+  for (var i = 0; i < callbacks.length; i++) {
+    callbacks[i](target);
   }
 }


### PR DESCRIPTION
This PR removes the check for the array in the `_injectDecoratorInitializer` function. It is unnecessary because all static properties are created automatically. Also, it would allow reducing the function's code size and improve performance.